### PR TITLE
Added more sane feedback .yml file errors, for issue #18

### DIFF
--- a/staffeli_nt/upload.py
+++ b/staffeli_nt/upload.py
@@ -92,6 +92,7 @@ if __name__ == '__main__':
         API_KEY = f.read().strip()
 
     # fetch every grading sheet
+    error_files = []
     for root, dirs, files in os.walk(path_submissions, followlinks=True):
         for name in files:
             if name != NAME_SHEET:
@@ -99,10 +100,19 @@ if __name__ == '__main__':
 
             path = os.path.join(root, name)
             with open(path, 'r') as f:
-                sheets.append((
-                    path,
-                    parse_sheet(f.read())
+                try:
+                    sheets.append((
+                        path,
+                        parse_sheet(f.read())
                     ))
+                except:
+                    error_files.append(path)
+
+    # Aborts if there are syntax errors in the .yml files, and prints offenders
+    if error_files:
+        print ("There were errors in the following files:")
+        print (*error_files, sep="\n")
+        exit()
 
     # check that every sheet is complete
     graded = True

--- a/staffeli_nt/upload.py
+++ b/staffeli_nt/upload.py
@@ -5,7 +5,7 @@ import sys
 import tempfile
 
 from pathlib import Path
-
+from ruamel.yaml import YAMLError
 from vas import *
 from util import *
 
@@ -105,7 +105,12 @@ if __name__ == '__main__':
                         path,
                         parse_sheet(f.read())
                     ))
+                except YAMLError as exc:
+                    print(f"\nFailed to parse {path}:")
+                    print(f"  {str(exc)}\n")
+                    error_files.append(path)
                 except:
+                    print(f"Some error in {path}")
                     error_files.append(path)
 
     # Aborts if there are syntax errors in the .yml files, and prints offenders


### PR DESCRIPTION
Handles feedback .yml file errors by printing them all so you can see which ones are the offenders.
This does remove the error messages for each file unfortunately, but is should still be easier to work with than having to look through each and every one.