### PR TITLE
Support for tasks with no points

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,25 +64,25 @@ There are multiple options for fetching submissions.
 The general command is `download.py <course_id> <template.yaml> <assignment-dir> [flags]`, where
 - `<course_id>` is the canvas `course_id` for the course.
 - `<template.yaml>` is the template file to use when generating the `grade.yml` file for each submission
-- `<assignment_dir>` is a *non-existing* directory, that staffeli will create and store the submissions in. 
+- `<assignment_dir>` is a *non-existing* directory, that staffeli will create and store the submissions in.
 
 To fetch **all** submissions from the course with id 42376, using the template-file `ass1-template.yml` and create a new directory "ass1dir" to store the submissions in:
 
     $ <staffeli_nt_path>/download.py 42376 ass1-template.yml ass1dir
 
-This will present you with a list of assignments for the course, where you will interactively choose which assignment to fetch. 
+This will present you with a list of assignments for the course, where you will interactively choose which assignment to fetch.
 
 ### Flags
 #### Fetching all submissions for a section
-What we call "Hold", canvas/absalon calls sections. 
+What we call "Hold", canvas/absalon calls sections.
 To fetch all submissions for an assignment, where the student belongs to a given section:
 
     $ <staffeli_nt_path>/download.py 42376 ass1-template.yml ass1dir --select-section
 
-This will present you with a list of assignments for the course, where you will interactively choose which assignment to fetch, followed by a list of sections for you to choose from. 
+This will present you with a list of assignments for the course, where you will interactively choose which assignment to fetch, followed by a list of sections for you to choose from.
 
 #### Fetching specific submissions (based on kuid)
-It is possible to fetch specific submissions based on a list of kuids. 
+It is possible to fetch specific submissions based on a list of kuids.
 To do this, create a YAML-file with the following format:
 
 ``` yaml
@@ -99,11 +99,11 @@ To then fetch all submissions for an assignment for a given TA:
 
     $ <staffeli_nt_path>/download.py 42376 ass1-template.yml ass1dir --select-ta ta_list.yml
 
-where `ta_list.yml` is a YAML-file following the above format. 
+where `ta_list.yml` is a YAML-file following the above format.
 
 
-This will present you with a list of assignments for the course, where you will interactively choose which assignment to fetch, followed by the list of TA's from your `ta_list.yml` file. 
-Selecting a TA, will fetch submissions from each `kuid` in the file, associated with the chosen TA, i.e. selecting `TA1` will fetch submission from `kuid1`, `kuid2` and `kuid3`. 
+This will present you with a list of assignments for the course, where you will interactively choose which assignment to fetch, followed by the list of TA's from your `ta_list.yml` file.
+Selecting a TA, will fetch submissions from each `kuid` in the file, associated with the chosen TA, i.e. selecting `TA1` will fetch submission from `kuid1`, `kuid2` and `kuid3`.
 
 
 ### Automatically running onlineTA for each submission
@@ -111,7 +111,7 @@ In the `template.yml`-file you can add a field:
 
 `onlineTA: https://address.of.onlineTA.dk/grade/assignmentName`
 
-This will (attempt to) run onlineTA for each downloaded submission. 
+This will (attempt to) run onlineTA for each downloaded submission.
 
 
 Upload Feedback and grades
@@ -164,17 +164,17 @@ tasks:
 
 ### Optional fields
 
-The template files support a few optional fields. 
+The template files support a few optional fields.
 
-- `passing-points: N`:  
+- `passing-points: N`:
 Adding this field will have the effect, that the grade posted is `1` if the total sum of points is
 greater than or equal to `passing-points`, and `0` otherwise.
-- `show-points: BOOL`  
-Setting show-points to `false` will exclude the `points/grade` from the generated `feedback.txt` files. 
-Use this, if you do not want the students to see the points-per-task, but only receive an overall grade. 
+- `show-points: BOOL`
+Setting show-points to `false` will exclude the `points/grade` from the generated `feedback.txt` files.
+Use this, if you do not want the students to see the points-per-task, but only receive an overall grade.
 
-- `onlineTA: ADDR`  
-Include this field to (attempt to) run onlineTA at address `ADDR` for each submission, when downloading submissions. 
+- `onlineTA: ADDR`
+Include this field to (attempt to) run onlineTA at address `ADDR` for each submission, when downloading submissions.
 
 
 ### Fully fledged example template
@@ -188,10 +188,10 @@ tasks:
   - megaAssignmentGeneral:
       title: Mega assignment - General comments and adherence to hand-in format requirements
       points: 100
-      rubric: | 
+      rubric: |
         [*] You should spell check your assignments before handing them in
-        [-] You are using the charset iso-8859-1. Please move to the modern age. 
-        [-] Your zip-file contains a lot of junk. Please be aware of what you hand in. 
+        [-] You are using the charset iso-8859-1. Please move to the modern age.
+        [-] Your zip-file contains a lot of junk. Please be aware of what you hand in.
 
   - megaAssignmentTask1:
       title: Task 1
@@ -200,15 +200,20 @@ tasks:
         [+] Your implementation follows the API
         [-] Your implementation does not follow the API
         [+] Your tests are brilliant
-        [-] Your tests are not tests, just print-statements. 
-            This is equivalent to an exam without an examinator, where you shout 
+        [-] Your tests are not tests, just print-statements.
+            This is equivalent to an exam without an examinator, where you shout
             in a room for half an hour and give yourself the grade 12.
 
   - megaAssignmentTask2:
       title: Task 2
       points: 2
       rubric: |
-        [+] Very good points. 
-        [+] Very good points. However, I disagree with ... 
-        [-] I fail to comprehend you answer to this task. 
+        [+] Very good points.
+        [+] Very good points. However, I disagree with ...
+        [-] I fail to comprehend you answer to this task.
+
+  - megaAssignmentBonusTask:
+      title: Bonus tasks that do not give points, or another option for general comments
+      rubric: |
+        [*] You did extra work! It won't help you though.
 ```

--- a/staffeli_nt/vas.py
+++ b/staffeli_nt/vas.py
@@ -43,7 +43,8 @@ class Assignment:
         self.show_points = bool(show_points) if show_points is not None else True
         self.onlineTA = onlineTA
         for task in self.tasks:
-            self.total_points += task.points
+            if task.points is not None:
+                self.total_points += task.points
 
     def format_md(self, sheet):
         assert isinstance(sheet, GradingSheet)
@@ -192,12 +193,10 @@ class Solution:
 
     def serialize(self):
 
-        inner = [
-            ('grade', self.grade),
-            ('feedback', self.feedback)
-        ]
+        inner = [ ('feedback', self.feedback) ]
 
         if self.points is not None:
+            inner.append(('grade', self.grade))
             inner.append(('points', self.points))
 
         if self.bonus is not None:
@@ -209,6 +208,9 @@ class Solution:
 
     def get_grade(self, task: Task, with_bonus=True):
         bonus = 0 if (self.bonus is None) or (not with_bonus) else self.bonus
+
+        if self.points is None:
+            return 0
 
         if self.grade is not None:
             return self.grade + bonus
@@ -287,7 +289,7 @@ def parse_sheet(data):
                 name = k,
                 bonus = v['bonus'] if 'bonus' in v else None,
                 points = v['points'] if 'points' in v else None,
-                grade = v['grade'],
+                grade = v['grade'] if 'points' in v else None,
                 feedback = v['feedback']  if 'feedback' in v else None
             )
             for (k, v) in flat(struct['solutions'])


### PR DESCRIPTION
Small quality of life change that allows templates to exclude a points field for tasks. Suitable for general comments or bonus tasks that don't affect the overall grade. grade.yml files can now look like this:
```yaml
- Assignment1General:
      feedback: |
          [*] You should spell check your assignments before handing them in.
          [-] You did not include a zip-file with code, please upload.
```
Instead of this:
```yaml
- Assignment1General:
      grade:
      points: 0
      feedback: |
          [*] You should spell check your assignments before handing them in.
          [-] You did not include a zip-file with code, please upload.
```
This means that people grading don't need to input points to tasks with 0 points.