### PR TITLE
Fix for handins with multiple zip files

### DIFF
--- a/staffeli_nt/download.py
+++ b/staffeli_nt/download.py
@@ -203,22 +203,22 @@ if __name__ == '__main__':
             with open(path, 'wb') as bf:
                 bf.write(data)
 
-            if no_unzip:
-                # unzip attachments
-                if attachment['mime_class'] == 'zip':
-                    unpacked = os.path.join(base, 'unpacked')
-                    os.mkdir(unpacked)
-                    try:
-                        with zipfile.ZipFile(path, 'r') as zip_ref:
-                            try:
-                                zip_ref.extractall(unpacked)
-                                # Run through onlineTA
-                                if template.onlineTA is not None:
-                                    run_onlineTA(base, unpacked, template.onlineTA)
-                            except NotADirectoryError:
-                                print(f"Attempted to unzip into a non-directory: {name}")
-                    except BadZipFile:
-                        print(f"Attached archive not a zip-file: {name}")
+            if no_unzip: continue
+            # unzip attachments
+            if attachment['mime_class'] == 'zip':
+                unpacked = os.path.join(base, 'unpacked')
+                os.mkdir(unpacked)
+                try:
+                    with zipfile.ZipFile(path, 'r') as zip_ref:
+                        try:
+                            zip_ref.extractall(unpacked)
+                            # Run through onlineTA
+                            if template.onlineTA is not None:
+                                run_onlineTA(base, unpacked, template.onlineTA)
+                        except NotADirectoryError:
+                            print(f"Attempted to unzip into a non-directory: {name}")
+                except BadZipFile:
+                    print(f"Attached archive not a zip-file: {name}")
         # remove junk from submission directory
         junk = [
             '.git',

--- a/staffeli_nt/download.py
+++ b/staffeli_nt/download.py
@@ -53,7 +53,9 @@ if __name__ == '__main__':
     select_ta = ta_file(sys.argv) # use --select-ta file.yaml
 
     resubmissions_only = '--resub' in sys.argv
-    
+
+    no_unzip = '--no-unzip' in sys.argv
+
     # sanity check
     with open(path_template, 'r') as f:
         template = parse_template(f.read())
@@ -201,21 +203,22 @@ if __name__ == '__main__':
             with open(path, 'wb') as bf:
                 bf.write(data)
 
-            # unzip attachments
-            if attachment['mime_class'] == 'zip':
-                unpacked = os.path.join(base, 'unpacked')
-                os.mkdir(unpacked)
-                try:
-                    with zipfile.ZipFile(path, 'r') as zip_ref:
-                        try:
-                            zip_ref.extractall(unpacked)
-                            # Run through onlineTA
-                            if template.onlineTA is not None:
-                                run_onlineTA(base, unpacked, template.onlineTA)
-                        except NotADirectoryError:
-                            print(f"Attempted to unzip into a non-directory: {name}")
-                except BadZipFile:
-                    print(f"Attached archive not a zip-file: {name}")
+            if no_unzip:
+                # unzip attachments
+                if attachment['mime_class'] == 'zip':
+                    unpacked = os.path.join(base, 'unpacked')
+                    os.mkdir(unpacked)
+                    try:
+                        with zipfile.ZipFile(path, 'r') as zip_ref:
+                            try:
+                                zip_ref.extractall(unpacked)
+                                # Run through onlineTA
+                                if template.onlineTA is not None:
+                                    run_onlineTA(base, unpacked, template.onlineTA)
+                            except NotADirectoryError:
+                                print(f"Attempted to unzip into a non-directory: {name}")
+                    except BadZipFile:
+                        print(f"Attached archive not a zip-file: {name}")
         # remove junk from submission directory
         junk = [
             '.git',


### PR DESCRIPTION
Currently the download.py script crashes if students hand in more than one zip file as it attempts to unpack both.
I only have time to add a small workaround in the form of a --no-unzip flag but think it would be a good idea to handle it in a better way.