### PR TITLE
Pass/fail support

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,3 +217,11 @@ tasks:
       rubric: |
         [*] You did extra work! It won't help you though.
 ```
+
+Pass/fail/complete/incomplete
+-----------------------------
+
+Instead of a number of points, tasks may be graded as `pass` (or
+`complete`) or `fail` (or `incomplete`). The template still expects a
+`points` field for pass/fail assignments, `0` is probably an
+appropriate choice.

--- a/staffeli_nt/upload.py
+++ b/staffeli_nt/upload.py
@@ -85,11 +85,18 @@ if __name__ == '__main__':
     with open(meta_file, 'r') as f:
         meta = parse_meta(f.read())
 
-    with open(path_template, 'r') as f:
-        tmpl = parse_template(f.read())
-
     with open(path_token, 'r') as f:
         API_KEY = f.read().strip()
+
+    # obtain canvas session
+    API_URL = 'https://absalon.ku.dk/'
+
+    canvas = Canvas(API_URL, API_KEY)
+    course = canvas.get_course(meta.course.id)
+    assignment = course.get_assignment(meta.assignment.id)
+
+    with open(path_template, 'r') as f:
+        tmpl = parse_template(f.read(), assignment.grading_type)
 
     # fetch every grading sheet
     error_files = []
@@ -137,12 +144,6 @@ if __name__ == '__main__':
             assert student.id not in handins, 'student assigned multiple sheets'
             handins[student.id] = sheet
 
-    # obtain canvas session
-    API_URL = 'https://absalon.ku.dk/'
-
-    canvas = Canvas(API_URL, API_KEY)
-    course = canvas.get_course(meta.course.id)
-    assignment = course.get_assignment(meta.assignment.id)
     submissions = []
     section = None
 


### PR DESCRIPTION
Addresses issue #45. It's ugly to have to pass metadata (the grading type) to `parse_template`, but I couldn't really see a nicer way to do it without changing more stuff; it seems stupid to make the grading type part of the templates themselves.

I've made the arbitrary decision that if an assignment has multiple tasks, if any of them are graded `fail` or `incomplete` then the assignment as a whole is failed.