### PR TITLE
Add minimal documentation for --resub flag and minimal exception handling for malformed ta-lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,13 @@ In the `template.yml`-file you can add a field:
 This will (attempt to) run onlineTA for each downloaded submission.
 
 
+#### Fetching only ungraded submissions (resubs)
+It is possile to only fetch submissions that are either ungraded or have a score < 1.0.
+Currently this is implemented specifically for the PoP-course and might not be available in the current form in later releases. 
+This can be achieved by appending the `--resub` flag to any use of the `download.py`-script.
+
+
+
 Upload Feedback and grades
 --------------------------
 

--- a/staffeli_nt/download.py
+++ b/staffeli_nt/download.py
@@ -79,8 +79,11 @@ if __name__ == '__main__':
     ta = None
     if select_ta:
         with open(select_ta, 'r') as f:
-            (tas,stud) = parse_students_and_tas(f)
-
+            try:
+                (tas,stud) = parse_students_and_tas(f)
+            except Exception as e:
+                print(f"Failed to parse ta-list. Do all TA's have at least one student attached?\nexiting.")
+                sys.exit(1)
         print('\nTAs:')
         for n, ta in enumerate(tas):
             print('%2d :' % n, ta)


### PR DESCRIPTION
I added minimal documentation for the --resub flag. 
I believe we should create a new issue to rewrite this feature entirely. 
Currently it is a hack and does not really fetch resubmissions, but ungraded submissions or sumissions with a score of < 1.0. 

Somewhat solves #37 

See also #33 that mentions pitfalls regarding the current implementation.