### PR TITLE
Add more fool-proof instructions in readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,11 @@ clones compatible with git.
 
 We recommend that you create a local directory ``canvas``,
 ``absalon``, or similar, for all of you Canvas-related local course
-clones. Staffeli needs some initial help to be able to login with your
+clones.
+
+Obtain your personal Canvas token
+---------------------------------
+Staffeli needs some initial help to be able to login with your
 credentials. You need to [generate a
 token](https://guides.instructure.com/m/4214/l/40399-how-do-i-obtain-an-api-access-token-for-an-account)
 for Staffeli to use, and save it in your home directory in a file with
@@ -61,14 +65,20 @@ Fetch Submissions for an Assignment
 -----------------------------------
 There are multiple options for fetching submissions.
 
-The general command is `download.py <course_id> <template.yaml> <assignment-dir> [flags]`, where
+The general command is `<staffeli_nt_path>/download.py <course_id> <template.yaml> <assignment-dir> [flags]`, where
+- `<staffeli_nt_path>` is the path to the directory where `staffeli_nt` is located, i.e. where the files `download.py` and `upload.py` etc. can be found.
 - `<course_id>` is the canvas `course_id` for the course.
 - `<template.yaml>` is the template file to use when generating the `grade.yml` file for each submission
 - `<assignment_dir>` is a *non-existing* directory, that staffeli will create and store the submissions in.
 
-To fetch **all** submissions from the course with id 42376, using the template-file `ass1-template.yml` and create a new directory "ass1dir" to store the submissions in:
+**Windows**:  
+Since `staffeli_nt` is written in `python3`, you will need to invoke it via your `python3` interpreter. 
+Example: `python <staffeli_nt_path>/download.py <course_id> <template.yml> <assignment-dir> [flags]`
 
-    $ <staffeli_nt_path>/download.py 42376 ass1-template.yml ass1dir
+**Fetching all submissions**:  
+To fetch **all** submissions from the course with id `12345`, using the template-file `ass1-template.yml` and create a new directory "ass1dir" to store the submissions in:
+
+    $ <staffeli_nt_path>/download.py 12345 ass1-template.yml ass1dir
 
 This will present you with a list of assignments for the course, where you will interactively choose which assignment to fetch.
 For each submission, a directory will be created in `<assignment_dir>`, in which the handed-in files of the submission will be stored, alongside a file `grade.yml` generated form the `<template.yml>` for a TA to fill out during grading of the assignment.
@@ -79,9 +89,9 @@ Submission comments, if any, will be downloaded as well, and stored alongside `g
 ### Flags
 #### Fetching all submissions for a section
 What we call "Hold", canvas/absalon calls sections.
-To fetch all submissions for an assignment, where the student belongs to a given section:
+To fetch all submissions for an assignment, where the student belongs to a given section, and the `<course_id>` is `12345`:
 
-    $ <staffeli_nt_path>/download.py 42376 ass1-template.yml ass1dir --select-section
+    $ <staffeli_nt_path>/download.py 12345 ass1-template.yml ass1dir --select-section
 
 This will present you with a list of assignments for the course, where you will interactively choose which assignment to fetch, followed by a list of sections for you to choose from.
 
@@ -101,7 +111,7 @@ TA2:
 
 To then fetch all submissions for an assignment for a given TA:
 
-    $ <staffeli_nt_path>/download.py 42376 ass1-template.yml ass1dir --select-ta ta_list.yml
+    $ <staffeli_nt_path>/download.py <course_id> ass1-template.yml ass1dir --select-ta ta_list.yml
 
 where `ta_list.yml` is a YAML-file following the above format.
 


### PR DESCRIPTION
Some users of `staffeli_nt` are less experienced with command lines and operating systems. 
I have attempted to make the readme "more foolproof", hoping to alleviate some of the extra-TA'ing I do, explaining how computers work to other users of `staffeli_nt`. 