### PR TITLE
canvasapi 3.0.0 has breaking changes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-canvasapi>=2.0.0
+canvasapi==2.2.0
 ruamel.yaml>=0.16.10


### PR DESCRIPTION
Lock our requirement to 2.2.0, at least until we can update our code to the 3.0.0 API.

Solves #59 , at least temporarily.