### PR TITLE
Better redistribution algorithm and somewhat critical bugfix

### DIFF
--- a/staffeli_nt/info.py
+++ b/staffeli_nt/info.py
@@ -334,6 +334,8 @@ if __name__ == '__main__':
     if ("--get-ass-dist" in sys.argv):
         idx = sys.argv.index("--get-ass-dist")
         try:
+            while (sys.argv[idx+1] == "--debug" or sys.argv[idx+1] == "--quiet"):
+                idx += 1
             fname = sys.argv[idx+1]
         except:
             exit_error("Failed to find output filename")


### PR DESCRIPTION
- Bugfix:
    Students belonging to a "phony section" would be filtered out before redistribution and creating a ta_list.yml. 
    They are now "grabbed" before the "phony sections" are deleted, and will be included in the ta_list.yml
- Algorithm:
    Less code, less dictionaries, less passes, (hopefully) less bugs. 
- Extras: 
    Prettier info and debug prints